### PR TITLE
Feature#11 Add absence report for given year and month

### DIFF
--- a/app/admin/absence_report.rb
+++ b/app/admin/absence_report.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+ActiveAdmin.register_page 'Absence Report' do
+  content do
+    year = (params[:year] || Date.today.year).to_i
+    month = (params[:month] || Date.today.month).to_i
+    active_admin_form_for '', url: admin_absence_report_path, method: 'get', decorate: true do |f|
+      panel 'Selected month' do
+        Date.new(year, month).strftime('%B, %Y').to_s
+      end
+
+      f.inputs "Select month and year below..." do
+        f.input :year, type: 'select', collection: 2020..2050, selected: year
+        f.input :month, type: 'select', collection: 1..12, name: 'month', selected: month
+        f.button 'Send'
+      end
+    end
+
+    table_for Employee.absences_month(year, month), { class: 'index_table' } do
+      column :day
+      column(:employee_number) { |absence| absence[:employee].employee_number }
+      column(:employee)
+      column(:private_number) { |absence| absence[:employee].private_number }
+      column(:email) { |absence| absence[:employee].email }
+      column(:company_branch) { |absence| absence[:employee].company_branch }
+    end
+  end
+end

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: employees
@@ -23,5 +25,21 @@ class Employee < ApplicationRecord
   # override destroy action
   def destroy
     update(status: (status ? false : true))
+  end
+
+  def self.absences_month(year = Date.today.year, month = Date.today.month)
+    absences = []
+    Employee.all.each do |employee|
+      (Date.new(year, month)..Date.new(year, month, -1)).to_a.each do |day|
+        absences << { day: day, employee: employee } if employee.absence?(day)
+      end
+    end
+    absences
+  end
+
+  def absence?(day)
+    return false unless day <= Date.today
+
+    true unless EmployeeCheck.where(employee_id: id, created_at: day.midnight..day.end_of_day).count.positive?
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,7 +16,7 @@ module Kata07RejojChecadorEquipo04K07
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = "Mexico City"
     # config.eager_load_paths << Rails.root.join("extras")
   end
 end

--- a/spec/models/employee_check_spec.rb
+++ b/spec/models/employee_check_spec.rb
@@ -39,4 +39,17 @@ RSpec.describe EmployeeCheck, type: :model do
       expect(employee_check_two.check_type).to eq 'check_out'
     end
   end
+
+  context 'employee absences' do
+    it 'returns true when there is an absence in given day' do
+      absence = employees(:one).absence? Date.today
+      expect(absence).to eq true
+    end
+
+    it 'returns false when there is not an absence in given day' do
+      described_class.create(private_number: employees(:one).private_number)
+      absence = employees(:one).absence? Date.today
+      expect(absence).to eq nil
+    end
+  end
 end


### PR DESCRIPTION
# Description
Add a view to show employees absence report giving a month and year, to know when an employee has no checks:
 - Add function to employee model called absence? to check if the employee has an absence in a giving a day.
 - Add function to employee model to retrieve all the employee absences.
 - Generate activeadmin page called Absence Report. 
 - Test the actions in the employee model. 

These changes add the fetaure required in isuue #11 
 
 # Testing
Just run in your console:
```bash
rspec
```
or go to the activeadmin panel and select absence report option then select a year and month and click send button.
 
  ## Screenshots 
![image](https://user-images.githubusercontent.com/16063732/116164291-2387d180-a6bf-11eb-87ac-9c7443dfa9a7.png)

